### PR TITLE
Flk 1513 - Module 1 labs

### DIFF
--- a/hourly-tips/src/main/java/org/apache/flink/training/exercises/hourlytips/HourlyTipsExercise.java
+++ b/hourly-tips/src/main/java/org/apache/flink/training/exercises/hourlytips/HourlyTipsExercise.java
@@ -19,15 +19,20 @@
 package org.apache.flink.training.exercises.hourlytips;
 
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.training.exercises.common.datatypes.TaxiFare;
 import org.apache.flink.training.exercises.common.sources.TaxiFareGenerator;
-import org.apache.flink.training.exercises.common.utils.MissingSolutionException;
+import org.apache.flink.util.Collector;
 
 /**
  * The Hourly Tips exercise from the Flink training.
@@ -40,7 +45,9 @@ public class HourlyTipsExercise {
     private final SourceFunction<TaxiFare> source;
     private final SinkFunction<Tuple3<Long, Long, Float>> sink;
 
-    /** Creates a job using the source and sink provided. */
+    /**
+     * Creates a job using the source and sink provided.
+     */
     public HourlyTipsExercise(
             SourceFunction<TaxiFare> source, SinkFunction<Tuple3<Long, Long, Float>> sink) {
 
@@ -72,22 +79,38 @@ public class HourlyTipsExercise {
         // set up streaming execution environment
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
+        WatermarkStrategy<TaxiFare> strategy = WatermarkStrategy
+                .<TaxiFare>forMonotonousTimestamps()
+                .withTimestampAssigner((event, timestamp) -> event.getEventTimeMillis());
+
         // start the data generator
-        DataStream<TaxiFare> fares = env.addSource(source);
+        DataStream<TaxiFare> fares = env.addSource(source)
+                .assignTimestampsAndWatermarks(strategy);
 
-        // replace this with your solution
-        if (true) {
-            throw new MissingSolutionException();
-        }
+        fares.keyBy(fare -> fare.driverId)
+                .window(TumblingEventTimeWindows.of(Time.hours(1)))
+                .process(new AddTips())
+                .windowAll(TumblingEventTimeWindows.of(Time.hours(1)))
+                .maxBy(2)
+                .addSink(sink);
 
-        // the results should be sent to the sink that was passed in
-        // (otherwise the tests won't work)
-        // you can end the pipeline with something like this:
-
-        // DataStream<Tuple3<Long, Long, Float>> hourlyMax = ...
-        // hourlyMax.addSink(sink);
-
-        // execute the pipeline and return the result
         return env.execute("Hourly Tips");
+    }
+
+    public static class AddTips
+            extends ProcessWindowFunction<TaxiFare, Tuple3<Long, Long, Float>, Long, TimeWindow> {
+
+        @Override
+        public void process(Long key,
+                            Context context,
+                            Iterable<TaxiFare> fares,
+                            Collector<Tuple3<Long, Long, Float>> out) {
+            float tipsSum = 0;
+
+            for (TaxiFare f: fares) {
+                tipsSum += f.tip;
+            }
+            out.collect(Tuple3.of(context.window().getEnd(), key, tipsSum));
+        }
     }
 }

--- a/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
+++ b/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
@@ -21,6 +21,8 @@ package org.apache.flink.training.exercises.longrides;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -30,7 +32,6 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide;
 import org.apache.flink.training.exercises.common.sources.TaxiRideGenerator;
-import org.apache.flink.training.exercises.common.utils.MissingSolutionException;
 import org.apache.flink.util.Collector;
 
 import java.time.Duration;
@@ -47,7 +48,9 @@ public class LongRidesExercise {
     private final SourceFunction<TaxiRide> source;
     private final SinkFunction<Long> sink;
 
-    /** Creates a job using the source and sink provided. */
+    /**
+     * Creates a job using the source and sink provided.
+     */
     public LongRidesExercise(SourceFunction<TaxiRide> source, SinkFunction<Long> sink) {
         this.source = source;
         this.sink = sink;
@@ -98,17 +101,42 @@ public class LongRidesExercise {
     @VisibleForTesting
     public static class AlertFunction extends KeyedProcessFunction<Long, TaxiRide, Long> {
 
+        private ValueState<TaxiRide> firstEvent;
+
         @Override
-        public void open(Configuration config) throws Exception {
-            throw new MissingSolutionException();
+        public void open(Configuration config) {
+            firstEvent = getRuntimeContext().getState(new ValueStateDescriptor<>("taxi ride event", TaxiRide.class));
         }
 
         @Override
-        public void processElement(TaxiRide ride, Context context, Collector<Long> out)
-                throws Exception {}
+        public void processElement(TaxiRide currentRide, Context context, Collector<Long> out)
+                throws Exception {
+            TaxiRide firstRide = firstEvent.value();
+            if (firstRide == null) {
+                firstEvent.update(currentRide);
+                if (currentRide.isStart) {
+                    context.timerService().registerEventTimeTimer(currentRide.getEventTimeMillis() + Duration.ofHours(2).toMillis());
+                }
+                return;
+            }
+            if (currentRide.isStart) {
+                if (Duration.between(currentRide.eventTime, firstRide.eventTime).compareTo(Duration.ofHours(2)) > 0) {
+                    out.collect(currentRide.rideId);
+                }
+            } else {
+                context.timerService().deleteEventTimeTimer(firstRide.getEventTimeMillis() + Duration.ofHours(2).toMillis());
+                if (Duration.between(firstRide.eventTime, currentRide.eventTime).compareTo(Duration.ofHours(2)) > 0) {
+                    out.collect(currentRide.rideId);
+                }
+            }
+            firstEvent.clear();
+        }
 
         @Override
-        public void onTimer(long timestamp, OnTimerContext context, Collector<Long> out)
-                throws Exception {}
+        public void onTimer(long timestamp, OnTimerContext context, Collector<Long> out) throws Exception {
+            TaxiRide taxiRide = firstEvent.value();
+            out.collect(taxiRide.rideId);
+            firstEvent.clear();
+        }
     }
 }

--- a/ride-cleansing/src/main/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingExercise.java
+++ b/ride-cleansing/src/main/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingExercise.java
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide;
 import org.apache.flink.training.exercises.common.sources.TaxiRideGenerator;
-import org.apache.flink.training.exercises.common.utils.MissingSolutionException;
+import static org.apache.flink.training.exercises.common.utils.GeoUtils.isInNYC;
 
 /**
  * The Ride Cleansing exercise from the Flink training.
@@ -79,8 +79,9 @@ public class RideCleansingExercise {
     /** Keep only those rides and both start and end in NYC. */
     public static class NYCFilter implements FilterFunction<TaxiRide> {
         @Override
-        public boolean filter(TaxiRide taxiRide) throws Exception {
-            throw new MissingSolutionException();
+        public boolean filter(TaxiRide taxiRide) {
+            return isInNYC(taxiRide.startLon, taxiRide.startLat)
+                    && isInNYC(taxiRide.endLon, taxiRide.endLat);
         }
     }
 }

--- a/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
+++ b/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
@@ -19,6 +19,8 @@
 package org.apache.flink.training.exercises.ridesandfares;
 
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -31,7 +33,6 @@ import org.apache.flink.training.exercises.common.datatypes.TaxiFare;
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide;
 import org.apache.flink.training.exercises.common.sources.TaxiFareGenerator;
 import org.apache.flink.training.exercises.common.sources.TaxiRideGenerator;
-import org.apache.flink.training.exercises.common.utils.MissingSolutionException;
 import org.apache.flink.util.Collector;
 
 /**
@@ -45,7 +46,9 @@ public class RidesAndFaresExercise {
     private final SourceFunction<TaxiFare> fareSource;
     private final SinkFunction<RideAndFare> sink;
 
-    /** Creates a job using the sources and sink provided. */
+    /**
+     * Creates a job using the sources and sink provided.
+     */
     public RidesAndFaresExercise(
             SourceFunction<TaxiRide> rideSource,
             SourceFunction<TaxiFare> fareSource,
@@ -59,7 +62,6 @@ public class RidesAndFaresExercise {
     /**
      * Creates and executes the pipeline using the StreamExecutionEnvironment provided.
      *
-     * @throws Exception which occurs during job execution.
      * @return {JobExecutionResult}
      */
     public JobExecutionResult execute() throws Exception {
@@ -67,14 +69,18 @@ public class RidesAndFaresExercise {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         // A stream of taxi ride START events, keyed by rideId.
-        DataStream<TaxiRide> rides =
-                env.addSource(rideSource).filter(ride -> ride.isStart).keyBy(ride -> ride.rideId);
+        DataStream<TaxiRide> rides = env.addSource(rideSource)
+                .filter(ride -> ride.isStart)
+                .keyBy(ride -> ride.rideId);
 
         // A stream of taxi fare events, also keyed by rideId.
-        DataStream<TaxiFare> fares = env.addSource(fareSource).keyBy(fare -> fare.rideId);
+        DataStream<TaxiFare> fares = env.addSource(fareSource)
+                .keyBy(fare -> fare.rideId);
 
         // Create the pipeline.
-        rides.connect(fares).flatMap(new EnrichmentFunction()).addSink(sink);
+        rides.connect(fares)
+                .flatMap(new EnrichmentFunction())
+                .addSink(sink);
 
         // Execute the pipeline and return the result.
         return env.execute("Join Rides with Fares");
@@ -98,20 +104,35 @@ public class RidesAndFaresExercise {
 
     public static class EnrichmentFunction
             extends RichCoFlatMapFunction<TaxiRide, TaxiFare, RideAndFare> {
+        private ValueState<TaxiRide> taxiRide;
+        private ValueState<TaxiFare> taxiFare;
 
         @Override
-        public void open(Configuration config) throws Exception {
-            throw new MissingSolutionException();
+        public void open(Configuration config) {
+            taxiRide = getRuntimeContext().getState(new ValueStateDescriptor<>("taxiRide", TaxiRide.class));
+            taxiFare = getRuntimeContext().getState(new ValueStateDescriptor<>("taxiFare", TaxiFare.class));
         }
 
         @Override
         public void flatMap1(TaxiRide ride, Collector<RideAndFare> out) throws Exception {
-            throw new MissingSolutionException();
+            TaxiFare fare = taxiFare.value();
+            if (fare == null) {
+                taxiRide.update(ride);
+                return;
+            }
+            taxiFare.clear();
+            out.collect(new RideAndFare(ride, fare));
         }
 
         @Override
         public void flatMap2(TaxiFare fare, Collector<RideAndFare> out) throws Exception {
-            throw new MissingSolutionException();
+            TaxiRide ride = taxiRide.value();
+            if (ride == null) {
+                taxiFare.update(fare);
+                return;
+            }
+            taxiRide.clear();
+            out.collect(new RideAndFare(ride, fare));
         }
     }
 }

--- a/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
+++ b/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
@@ -104,8 +104,8 @@ public class RidesAndFaresExercise {
 
     public static class EnrichmentFunction
             extends RichCoFlatMapFunction<TaxiRide, TaxiFare, RideAndFare> {
-        private ValueState<TaxiRide> taxiRide;
-        private ValueState<TaxiFare> taxiFare;
+        private transient ValueState<TaxiRide> taxiRide;
+        private transient ValueState<TaxiFare> taxiFare;
 
         @Override
         public void open(Configuration config) {


### PR DESCRIPTION
PR containing the solutions for labs 1 to 4 from Module 1 of Flink Training:
Lab 1 - Update filter to keep only rides that both start and end in NYC
Lab 2 - Join TaxiRide and TaxiFare into a new stream of RideAndFare records, by ride id
Lab 3 - Identify, for each hour, the driver earning the most tips, using windows
Lab 4 - Provide alerts when a taxi ride last more than two hour, keeping in mind that events can be out of order and "end ride" event might be missing